### PR TITLE
html5shim should use a protocol-relative URL

### DIFF
--- a/themes/default/index.template.php
+++ b/themes/default/index.template.php
@@ -207,7 +207,7 @@ function template_html_above()
 	// A little help for our friends
 	echo '
 	<!--[if lt IE 9]>
-		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+		<script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->';
 
 	echo '


### PR DESCRIPTION
When deployed to a SSL server, the stock Elkarte theme causes security warnings due to its insecure link to the html5shim. It should use a scheme-relative URL.

My personal preference would be to avoid linking to a googlecode resource, but this change at least addresses the security issue.
